### PR TITLE
Allow From override via API by correctly managing the sender in 'Aitor Garcia <aitor@linkingpaths.com>' format

### DIFF
--- a/lib/postmark.rb
+++ b/lib/postmark.rb
@@ -98,7 +98,7 @@ module Postmark
       options = Hash.new
       headers = extract_headers_according_to_message_format(message)
     
-      options["From"]        = message.from.first          if message.from
+      options["From"]        = message['from'].to_s
       options["ReplyTo"]     = message.reply_to.join(", ") if message.reply_to
       options["To"]          = message.to.join(", ")       if message.to
       options["Cc"]          = message.cc.join(", ")       if message.cc

--- a/spec/postmark_spec.rb
+++ b/spec/postmark_spec.rb
@@ -129,6 +129,12 @@ describe "Postmark" do
       tmail_message["CUSTOM-HEADER"] = "header"
       tmail_message.should be_serialized_to %q[{"Subject":"Hello!", "From":"sheldon@bigbangtheory.com", "To":"lenard@bigbangtheory.com", "TextBody":"Hello Sheldon!", "Headers":[{"Name":"Custom-Header", "Value":"header"}]}]
     end
+    
+    it "should encode from properly when name is used" do
+      tmail_message.from = "Sheldon Lee Cooper <sheldon@bigbangtheory.com>"
+      tmail_message.should be_serialized_to %q[{"Subject":"Hello!", "From":"Sheldon Lee Cooper <sheldon@bigbangtheory.com>", "To":"lenard@bigbangtheory.com", "TextBody":"Hello Sheldon!"}]
+    end
+    
 
     it "should encode reply to" do
       tmail_message.reply_to = ['a@a.com', 'b@b.com']
@@ -181,6 +187,11 @@ describe "Postmark" do
       mail_message.should be_serialized_to %q[{"Subject":"Hello!", "From":"sheldon@bigbangtheory.com", "To":"lenard@bigbangtheory.com", "TextBody":"Hello Sheldon!", "Headers":[{"Name":"Custom-Header", "Value":"header"}]}]
     end
     
+    it "should encode from properly when name is used" do
+      mail_message.from = "Sheldon Lee Cooper <sheldon@bigbangtheory.com>"
+      mail_message.should be_serialized_to %q[{"Subject":"Hello!", "From":"Sheldon Lee Cooper <sheldon@bigbangtheory.com>", "To":"lenard@bigbangtheory.com", "TextBody":"Hello Sheldon!"}]
+    end
+        
     it "should encode reply to" do
       mail_message.reply_to = ['a@a.com', 'b@b.com']
       mail_message.should be_serialized_to %q[{"Subject":"Hello!", "From":"sheldon@bigbangtheory.com", "ReplyTo":"a@a.com, b@b.com", "To":"lenard@bigbangtheory.com", "TextBody":"Hello Sheldon!"}]


### PR DESCRIPTION
Actually the gem is using 

>    options["From"]        = message.from.first

This will return always decoded email address like "aitor@linkingpaths.com" and will not set the 'From' option correctly for from directions like  'Aitor Garcia aitor@linkingpaths.com' that according to the Postmark API documentation is a requirement to override the Name in the sender:

> It is possible to override the Name in the sender signature through the API. This is useful if you want to use member’s information in the email while keeping your from email address. just pass the name in the From parameter, From: "John Smith sender@example.com".

source: http://developer.postmarkapp.com/developer-build.html#message-format
