### PR TITLE
Tiny fix to message_extensions/mail

### DIFF
--- a/lib/postmark/message_extensions/mail.rb
+++ b/lib/postmark/message_extensions/mail.rb
@@ -4,7 +4,11 @@ module Mail
     include Postmark::SharedMessageExtensions
     
     def html?
-      content_type.include?('text/html')
+      if content_type.nil?
+        false
+      else
+        content_type.include?('text/html')
+      end
     end
     
     def body_html


### PR DESCRIPTION
If you create a message with the Mail and Postmark gems and for some reason the message's content_type isn't set, postmark throws the following exception in message_extensions/mail.rb#html?:

   NoMethodError - undefined method `include?' for nil:NilClass:

A check that prevents this kind of exception is present in other methods in mail.rb that could be vulnerable, but not in `html?`. My tiny change fixes this problem so I can get maximum enjoyment of the postmark-gem. Pull it for fun and profit!

Thanks,
Austin
