### PR TITLE
Add error_code to DeliveryError

### DIFF
--- a/lib/postmark.rb
+++ b/lib/postmark.rb
@@ -16,7 +16,15 @@ require_local 'attachments_fix_for_mail'
 
 module Postmark
 
-  class DeliveryError       < StandardError; end
+  class DeliveryError < StandardError
+    attr_accessor :error_code
+
+    def initialize(message = nil, error_code = nil)
+      super(message)
+      self.error_code = error_code
+    end
+  end
+
   class UnknownError        < DeliveryError; end
   class InvalidApiKeyError  < DeliveryError; end
   class InvalidMessageError < DeliveryError; end

--- a/lib/postmark/http_client.rb
+++ b/lib/postmark/http_client.rb
@@ -35,11 +35,11 @@ module Postmark
       when 200
         return Postmark::Json.decode(response.body)
       when 401
-        raise InvalidApiKeyError, error_message(response.body)
+        raise error(InvalidApiKeyError, response.body)
       when 422
-        raise InvalidMessageError, error_message(response.body)
+        raise error(InvalidMessageError, response.body)
       when 500
-        raise InternalServerError, response.body
+        raise error(InternalServerError, response.body)
       else
         raise UnknownError, response
       end
@@ -71,6 +71,15 @@ module Postmark
 
     def error_message(response_body)
       Postmark::Json.decode(response_body)["Message"]
+    end
+
+    def error_message_and_code(response_body)
+      reply = Postmark::Json.decode(response_body)
+      [reply["Message"], reply["ErrorCode"]]
+    end
+
+    def error(clazz, response_body)
+      clazz.send(:new, *error_message_and_code(response_body))
     end
   end
 end


### PR DESCRIPTION
DeliveryError (and its derived classes) now get a 'error_code' property, set with the error code received from the server. This can be used to differentiate between various errors that all fall into InvalidMessageError, for example.
