### PR TITLE
Timeout errors not retried

### DIFF
--- a/lib/postmark.rb
+++ b/lib/postmark.rb
@@ -30,6 +30,7 @@ module Postmark
   class InvalidMessageError < DeliveryError; end
   class InternalServerError < DeliveryError; end
   class UnknownMessageType  < DeliveryError; end
+  class TimeoutError        < DeliveryError; end
 
   module ResponseParsers
     autoload :Json,          'postmark/response_parsers/json'
@@ -100,6 +101,8 @@ module Postmark
         raise
       end
     end
+  rescue Timeout::Error
+    raise TimeoutError.new($!)
   end
 
   def convert_message_to_options_hash(message)


### PR DESCRIPTION
Shouldn't timeout errors be caught and retried along with the various other delivery errors?

Seeing errors like this in my logs:

```
Timeout::Error: Timeout::Error
/usr/local/lib/ruby/1.9.1/net/protocol.rb:140:in `rescue in rbuf_fill'
/usr/local/lib/ruby/1.9.1/net/protocol.rb:134:in `rbuf_fill'
/usr/local/lib/ruby/1.9.1/net/protocol.rb:86:in `read'
/usr/local/lib/ruby/1.9.1/net/http.rb:2424:in `read_body_0'
/usr/local/lib/ruby/1.9.1/net/http.rb:2379:in `read_body'
/usr/local/lib/ruby/1.9.1/net/http.rb:979:in `block in post'
/usr/local/lib/ruby/1.9.1/net/http.rb:1194:in `block in transport_request'
/usr/local/lib/ruby/1.9.1/net/http.rb:2342:in `reading_body'
/usr/local/lib/ruby/1.9.1/net/http.rb:1193:in `transport_request'
/usr/local/lib/ruby/1.9.1/net/http.rb:1177:in `request'
/usr/local/lib/ruby/1.9.1/net/http.rb:1170:in `block in request'
/usr/local/lib/ruby/1.9.1/net/http.rb:627:in `start'
/usr/local/lib/ruby/1.9.1/net/http.rb:1168:in `request'
/usr/local/lib/ruby/1.9.1/net/http.rb:978:in `post'
vendor/bundle/ruby/1.9.1/gems/postmark-0.9.10/lib/postmark/http_client.rb:7:in `post'
vendor/bundle/ruby/1.9.1/gems/postmark-0.9.10/lib/postmark.rb:87:in `send_through_postmark'
vendor/bundle/ruby/1.9.1/gems/postmark-0.9.10/lib/postmark/handlers/mail.rb:12:in `deliver!'
[…]
```

Right now, this error and others from `Net::HTTP` are raised all the way up instead of being caught and either retried or wrapped in a `Postmark::DeliveryError`.

I'm willing to put some work into this, just want to make sure a patch would be merged.
