### PR TITLE
activesupport is required when using Mail gem

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -56,6 +56,7 @@ In addition to the +postmark+ gem you also need to install +tmail+ or +mail+ gem
     require 'rubygems'
     require 'postmark'
     require 'mail'
+    require 'active_support/core_ext'
 
     message = Mail.new
     message.delivery_method(Mail::Postmark, :api_key => "your-api-key")


### PR DESCRIPTION
This Mail example won't work because the postmark gem uses the to_json method from activesupport. I added it in to the example.
