### PR TITLE
Fix `Client#get_messages` for inbound messages

### DIFF
--- a/lib/postmark/api_client.rb
+++ b/lib/postmark/api_client.rb
@@ -69,7 +69,8 @@ module Postmark
       path, params = extract_messages_path_and_params(options)
       params[:offset] ||= 0
       params[:count] ||= 50
-      format_response http_client.get(path, params)['Messages']
+      messages_key = options[:inbound] ? 'InboundMessages' : 'Messages'
+      format_response http_client.get(path, params)[messages_key]
     end
 
     def get_message(id, options = {})

--- a/spec/unit/postmark/api_client_spec.rb
+++ b/spec/unit/postmark/api_client_spec.rb
@@ -172,9 +172,9 @@ describe Postmark::ApiClient do
 
   describe '#get_messages' do
     let(:http_client) { subject.http_client }
-    let(:response) { {"TotalCount" => 1, "Messages" => [{}]} }
 
     context 'given outbound' do
+      let(:response) { {"TotalCount" => 1, "Messages" => [{}]} }
 
       it 'requests data at /messages/outbound' do
         http_client.should_receive(:get).
@@ -186,6 +186,7 @@ describe Postmark::ApiClient do
     end
 
     context 'given inbound' do
+      let(:response) { {"TotalCount" => 1, "InboundMessages" => [{}]} }
 
       it 'requests data at /messages/inbound' do
         http_client.should_receive(:get).


### PR DESCRIPTION
The API seems to return inbound messages wrapped in an `InboundMessages` key:

``` javascript
{
       "TotalCount": 320,
  "InboundMessages": [{
             "From": "do_not_reply@apple.com",
             // ...
   }]
}   
```

This PR fixes the parsing behavior
