### PR TITLE
Update InactiveRecipientError to Handle New Message Format

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,8 @@
 = Changelog
 
+== Unreleased
+* Updated Postmark::InactiveRecipientError.parse_recipients method to handle current error message
+
 == 1.22.1
 * Migrated to ActiveCampaign
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,5 +14,5 @@ If you’d like to submit a pull request:
 * Do not mess with rakefile, version, or history.
 * Update the CHANGELOG, list your changes under Unreleased.
 * Update the README if necessary.
-* Write short, descriptive commit messages, following the format used in therepo.
+* Write short, descriptive commit messages, following the format used in the repo.
 * Send a pull request. Bonus points for topic branches.

--- a/lib/postmark/error.rb
+++ b/lib/postmark/error.rb
@@ -75,9 +75,12 @@ module Postmark
   class InactiveRecipientError < ApiInputError
     attr_reader :recipients
 
-    PATTERNS = [/^Found inactive addresses: (.+?)\.$/.freeze,
-                /these inactive addresses: (.+?)\. Inactive/.freeze,
-                /these inactive addresses: (.+?)\.?$/].freeze
+    PATTERNS = [
+      /Found inactive addresses: (.+?)\. Inactive/,
+      /^Found inactive addresses: (.+?)\.$/,
+      /these inactive addresses: (.+?)\. Inactive/,
+      /these inactive addresses: (.+?)\.?$/
+    ].freeze
 
     def self.parse_recipients(message)
       PATTERNS.each do |p|

--- a/spec/unit/postmark/error_spec.rb
+++ b/spec/unit/postmark/error_spec.rb
@@ -186,10 +186,10 @@ describe(Postmark::InactiveRecipientError) do
 
     context '1/1 inactive' do
       let(:message) do
-        'You tried to send to a recipient that has been marked as ' \
-        "inactive.\nFound inactive addresses: #{recipients[0]}.\n" \
+        'You tried to send to recipient(s) that has been marked as ' \
+        "inactive. Found inactive addresses: #{recipients[0]}. " \
         'Inactive recipients are ones that have generated a hard ' \
-        'bounce or a spam complaint.'
+        'bounce, a spam complaint, or a manual suppression.'
       end
 
       it {is_expected.to eq(recipients.take(1))}


### PR DESCRIPTION
This adds a pattern to InactiveRecipientError's `parse_recipients` to handle the error message that comes back from Postmark which looks like this:
```
"You tried to send to recipient(s) that have been marked as inactive. Found inactive addresses: invalid@example.com. Inactive recipients are ones that have generated a hard bounce, a spam complaint, or a manual suppression."
```