### PR TITLE
fix setting InactiveRecipientError#recipients

### DIFF
--- a/lib/postmark/error.rb
+++ b/lib/postmark/error.rb
@@ -75,7 +75,7 @@ module Postmark
   class InactiveRecipientError < ApiInputError
     attr_reader :recipients
 
-    PATTERNS = [/^Found inactive addresses: (.+?)\.$/.freeze,
+    PATTERNS = [/Found inactive addresses: (.+?)\.$/.freeze,
                 /these inactive addresses: (.+?)\. Inactive/.freeze,
                 /these inactive addresses: (.+?)\.?$/].freeze
 

--- a/spec/unit/postmark/error_spec.rb
+++ b/spec/unit/postmark/error_spec.rb
@@ -214,7 +214,7 @@ describe(Postmark::InactiveRecipientError) do
     context 'n/n inactive, n > 1' do
       let(:message) do
         'You tried to send to recipients that have all been marked as ' \
-        "inactive.\nFound inactive addresses: #{recipients.join(', ')}.\n" \
+        "inactive. Found inactive addresses: #{recipients.join(', ')}.\n" \
         'Inactive recipients are ones that have generated a hard bounce or a spam complaint.'
       end
 


### PR DESCRIPTION
I noticed that `InactiveRecipientError#recipients` was empty because one of the regexes was too strict.
It required that "Found inactive addresses" appeared at the start of a line, when in fact the error message was "You tried to send to recipient(s) that have been marked as inactive. Found inactive addresses: my@email.com. Inactive recipients are ones that have generated a hard bounce, a spam complaint, or a manual suppression.", i.e. there's a space before "Found inactive addresses" but not the start of a new line.