### PR TITLE
Fix CI failing for older Ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,8 @@ group :test do
   gem 'mime-types'
   gem 'activesupport'
   gem 'i18n', '~> 0.6.0'
-  gem 'yajl-ruby', '~> 1.0', :platforms => [:mingw, :mswin, :ruby]
+
+  # To support Ruby version <= 2.6
+  gem 'minitest', '<= 5.15.0'
+  gem 'yajl-ruby', '<= 1.4.1', :platforms => [:mingw, :mswin, :ruby]
 end


### PR DESCRIPTION
## What

Fixes recent problem of [builds failing due to dependencies dropping support for Ruby versions < 2.6.](https://app.circleci.com/pipelines/github/ActiveCampaign/postmark-gem/96/workflows/2af391e9-bde6-4ba8-872b-5125ee554a13/jobs/1054).

## How

Adds limits to the two gems affected. 
Both of these are dev dependencies, so shouldn't affect any users of the gem.

## Anything else
We should maybe consider whether there is still a need to continue to support for these older versions.