### PR TITLE
Increase HTTP Client default timeouts to reasonable values

### DIFF
--- a/lib/postmark/http_client.rb
+++ b/lib/postmark/http_client.rb
@@ -17,8 +17,8 @@ module Postmark
       :host => 'api.postmarkapp.com',
       :secure => true,
       :path_prefix => '/',
-      :http_read_timeout => 15,
-      :http_open_timeout => 5
+      :http_read_timeout => 60,
+      :http_open_timeout => 60
     }
 
     def initialize(api_token, options = {})


### PR DESCRIPTION
These timeout defaults seem incredibly low - most of our other network policies use 60 second timeouts (ie. internal API calls, webhooks, etc) so I'm updating this to match. It should also help with the API timeouts issue customers have been reporting.