### PR TITLE
Fix failing specs caused by latest version of mail gem

### DIFF
--- a/postmark.gemspec
+++ b/postmark.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "json"
 
-  s.add_development_dependency "mail"
+  s.add_development_dependency "mail", "~> 2.7.0" # https://github.com/mikel/mail/pull/1539
   s.add_development_dependency "rake"
 end


### PR DESCRIPTION
## What

Locks the `mail` dependency to `~> 2.7.0`

## Why

`v 2.8.0` of the mail gem is causing [tests to fail](https://app.circleci.com/pipelines/github/ActiveCampaign/postmark-gem/115/workflows/98f981da-bff4-4abb-b0ad-eaeb8045e873).

Currently investigating here https://github.com/mikel/mail/pull/1539, but since it's just a development dependency we can lock the version to the CI back to green for now.