### PR TITLE
Fix ree tests failing

### DIFF
--- a/postmark.gemspec
+++ b/postmark.gemspec
@@ -35,5 +35,6 @@ Gem::Specification.new do |s|
   s.add_dependency "json"
 
   s.add_development_dependency "mail", "~> 2.7.0" # https://github.com/mikel/mail/pull/1539
+  s.add_development_dependency "mini_mime", "< 1.1.4"
   s.add_development_dependency "rake"
 end


### PR DESCRIPTION
## What

Fixes ree-1.8.7 failing with the following [error message](https://app.circleci.com/pipelines/github/ActiveCampaign/postmark-gem/159/workflows/8b08b5e9-d14a-4b54-9424-17972724573c/jobs/1728):

```
mini_mime-1.1.5 requires ruby version >= 2.6.0, which is incompatible with the
current version, ruby 1.8.7p374
```

## How

Locks the `mini_mime` dependency of `mail` to a slightly older version.
Both of them are development dependencies. 
The issue in https://github.com/ActiveCampaign/postmark-gem/pull/135 is still a blocker.