### PR TITLE
Refactor Circle CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,11 +9,24 @@ workflows:
       - unit-tests:
           matrix:
             parameters:
-              version: ["2", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7"]
+              version: [
+                "circleci/ruby:2",
+                "circleci/ruby:2.1",
+                "circleci/ruby:2.2",
+                "circleci/ruby:2.3",
+                "circleci/ruby:2.4",
+                "circleci/ruby:2.5",
+                "circleci/ruby:2.6",
+                "circleci/ruby:2.7"
+              ]
       - unit-tests-legacy:
           matrix:
             parameters:
-              version: ["kneip/ree-1.8.7-2012.02","ruby:1.9.3","circleci/jruby:9"]
+              version: [
+                "kneip/ree-1.8.7-2012.02",
+                "ruby:1.9.3",
+                "circleci/jruby:9"
+              ]
 
 orbs:
   ruby: circleci/ruby@0.1.2
@@ -25,21 +38,16 @@ jobs:
       version:
         type: string
     docker:
-      - image: circleci/ruby:<< parameters.version >>
+      - image: << parameters.version >>
     steps:
       - checkout
-      - run:
-          name: Versions
-          command: |
-            echo "ruby: $(ruby --version)"
+      - check_version
 
       - run:
           name: Install dependencies
           command: bundle install
 
-      - run:
-          name: Run tests
-          command: bundle exec rake spec
+      - run_tests
 
   unit-tests-legacy:
     parallelism: 1
@@ -52,10 +60,7 @@ jobs:
       - image: << parameters.version >>
     steps:
       - checkout
-      - run:
-          name: Versions
-          command: |
-            echo "ruby: $(ruby --version)"
+      - check_version
 
       - run:
           name: Install dependencies
@@ -63,6 +68,19 @@ jobs:
             gem install bundler --version 1.17.3
             bundle install
 
+      - run_tests
+
+commands:
+  check_version:
+    steps:
+      - run:
+          name: Check Ruby version
+          command: |
+            echo "ruby: $(ruby --version)"
+  run_tests:
+    steps:
       - run:
           name: Run tests
           command: bundle exec rake spec
+      - store_test_results:
+          path: test-results


### PR DESCRIPTION
## What

- Allows specifying full name of Circle CI images, as some of the new ones have a different prefix (`cimg/ruby`).
- DRY's up some of the steps.
- Stores test artifacts for easier debugging.

## Why

Prep work for adding Ruby 3+ to CircleCI in #144 