### PR TITLE
Unlock mail gem version for newer ruby versions

### DIFF
--- a/gemfiles/Gemfile.legacy
+++ b/gemfiles/Gemfile.legacy
@@ -10,7 +10,9 @@ group :test do
   gem 'rspec-its', '~> 1.2'
   gem 'fakeweb', :git => 'https://github.com/chrisk/fakeweb.git'
   gem 'fakeweb-matcher'
+  gem 'mail', '~> 2.7.0'
   gem 'mime-types', '~> 1.25.1'
+  gem 'mini_mime', '< 1.1.4'
   gem 'activesupport', '~> 3.2.0'
   gem 'i18n', '~> 0.6.0'
   gem 'yajl-ruby', '~> 1.0', '< 1.4.0', :platforms => [:mingw, :mswin, :ruby]

--- a/postmark.gemspec
+++ b/postmark.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "json"
 
-  s.add_development_dependency "mail", "~> 2.7.0" # https://github.com/mikel/mail/pull/1539
-  s.add_development_dependency "mini_mime", "< 1.1.4"
+  s.add_development_dependency "mail"
   s.add_development_dependency "rake"
 end

--- a/spec/unit/postmark/mail_message_converter_spec.rb
+++ b/spec/unit/postmark/mail_message_converter_spec.rb
@@ -118,8 +118,8 @@ describe Postmark::MailMessageConverter do
       from "sheldon@bigbangtheory.com"
       to "lenard@bigbangtheory.com"
       subject "Hello!"
-      body "Hello Sheldon!"
       add_file empty_gif_path
+      body "Hello Sheldon!"
     end
   end
 


### PR DESCRIPTION
## What

Alternate workaround to #135 and #143.

## Why

While there still seems to be an [issue with `add_mail` "clearing" `body`,](https://github.com/mikel/mail/pull/1539) instead of locking the gem for all ruby version and making it difficult to test newer ones, we can limit the version restrictions to legacy version and use this workaround of flipping the order for Ruby 2.x.