### PR TITLE
Add assertions to assertion-less tests

### DIFF
--- a/spec/unit/postmark/account_api_client_spec.rb
+++ b/spec/unit/postmark/account_api_client_spec.rb
@@ -37,7 +37,8 @@ describe Postmark::AccountApiClient do
       end
 
       it 'lazily loads senders' do
-        allow(subject.http_client).to receive(:get).
+        expect(subject.http_client).to receive(:get).
+            exactly(5).times.
             with('senders', an_instance_of(Hash)).and_return(response)
         subject.senders.take(1000)
       end
@@ -63,20 +64,20 @@ describe Postmark::AccountApiClient do
       end
 
       it 'performs a GET request to /senders endpoint' do
-        allow(subject.http_client).to receive(:get).
+        expect(subject.http_client).to receive(:get).
             with('senders', :offset => 0, :count => 30).
             and_return(response)
         subject.get_senders
       end
 
       it 'formats the keys of returned list of senders' do
-        allow(subject.http_client).to receive(:get).and_return(response)
+        expect(subject.http_client).to receive(:get).and_return(response)
         keys = subject.get_senders.map { |s| s.keys }.flatten
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
       it 'accepts offset and count options' do
-        allow(subject.http_client).to receive(:get).
+        expect(subject.http_client).to receive(:get).
             with('senders', :offset => 10, :count => 42).
             and_return(response)
         subject.get_senders(:offset => 10, :count => 42)
@@ -92,7 +93,7 @@ describe Postmark::AccountApiClient do
       end
 
       it 'returns a total number of senders' do
-        allow(subject.http_client).to receive(:get).
+        expect(subject.http_client).to receive(:get).
             with('senders', an_instance_of(Hash)).and_return(response)
         expect(subject.get_senders_count).to eq(42)
       end
@@ -115,13 +116,13 @@ describe Postmark::AccountApiClient do
       end
 
       it 'performs a GET request to /senders/:id endpoint' do
-        allow(subject.http_client).to receive(:get).with("senders/42").
+        expect(subject.http_client).to receive(:get).with("senders/42").
                                                     and_return(response)
         subject.get_sender(42)
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:get).and_return(response)
+        expect(subject.http_client).to receive(:get).and_return(response)
         keys = subject.get_sender(42).keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
@@ -144,19 +145,19 @@ describe Postmark::AccountApiClient do
       end
 
       it 'performs a POST request to /senders endpoint' do
-        allow(subject.http_client).to receive(:post).
+        expect(subject.http_client).to receive(:post).
             with("senders", an_instance_of(String)).and_return(response)
         subject.create_sender(:name => 'Chris Nagele')
       end
 
       it 'converts the sender attributes names to camel case' do
-        allow(subject.http_client).to receive(:post).
+        expect(subject.http_client).to receive(:post).
             with("senders", {'FooBar' => 'bar'}.to_json).and_return(response)
         subject.create_sender(:foo_bar => 'bar')
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:post).and_return(response)
+        expect(subject.http_client).to receive(:post).and_return(response)
         keys = subject.create_sender(:foo => 'bar').keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
@@ -180,19 +181,19 @@ describe Postmark::AccountApiClient do
       end
 
       it 'performs a PUT request to /senders/:id endpoint' do
-        allow(subject.http_client).to receive(:put).
+        expect(subject.http_client).to receive(:put).
             with('senders/42', an_instance_of(String)).and_return(response)
         subject.update_sender(42, :name => 'Chris Nagele')
       end
 
       it 'converts the sender attributes names to camel case' do
-        allow(subject.http_client).to receive(:put).
+        expect(subject.http_client).to receive(:put).
             with('senders/42', {'FooBar' => 'bar'}.to_json).and_return(response)
         subject.update_sender(42, :foo_bar => 'bar')
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:put).and_return(response)
+        expect(subject.http_client).to receive(:put).and_return(response)
         keys = subject.update_sender(42, :foo => 'bar').keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
@@ -212,13 +213,13 @@ describe Postmark::AccountApiClient do
       end
 
       it 'performs a POST request to /senders/:id/resend endpoint' do
-        allow(subject.http_client).to receive(:post).
+        expect(subject.http_client).to receive(:post).
             with('senders/42/resend').and_return(response)
         subject.resend_sender_confirmation(42)
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:post).and_return(response)
+        expect(subject.http_client).to receive(:post).and_return(response)
         keys = subject.resend_sender_confirmation(42).keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
@@ -233,18 +234,18 @@ describe Postmark::AccountApiClient do
       end
 
       it 'performs a POST request to /senders/:id/verifyspf endpoint' do
-        allow(subject.http_client).to receive(:post).
+        expect(subject.http_client).to receive(:post).
             with('senders/42/verifyspf').and_return(response)
         subject.verified_sender_spf?(42)
       end
 
       it 'returns false when SPFVerified field of the response is false' do
-        allow(subject.http_client).to receive(:post).and_return(false_response)
+        expect(subject.http_client).to receive(:post).and_return(false_response)
         expect(subject.verified_sender_spf?(42)).to be false
       end
 
       it 'returns true when SPFVerified field of the response is true' do
-        allow(subject.http_client).to receive(:post).and_return(response)
+        expect(subject.http_client).to receive(:post).and_return(response)
         expect(subject.verified_sender_spf?(42)).to be true
       end
     end
@@ -267,13 +268,13 @@ describe Postmark::AccountApiClient do
       end
 
       it 'performs a POST request to /senders/:id/requestnewdkim endpoint' do
-        allow(subject.http_client).to receive(:post).
+        expect(subject.http_client).to receive(:post).
             with('senders/42/requestnewdkim').and_return(response)
         subject.request_new_sender_dkim(42)
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:post).and_return(response)
+        expect(subject.http_client).to receive(:post).and_return(response)
         keys = subject.request_new_sender_dkim(42).keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
@@ -292,13 +293,13 @@ describe Postmark::AccountApiClient do
       end
 
       it 'performs a DELETE request to /senders/:id endpoint' do
-        allow(subject.http_client).to receive(:delete).
+        expect(subject.http_client).to receive(:delete).
             with('senders/42').and_return(response)
         subject.delete_sender(42)
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:delete).and_return(response)
+        expect(subject.http_client).to receive(:delete).and_return(response)
         keys = subject.delete_sender(42).keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
@@ -312,7 +313,8 @@ describe Postmark::AccountApiClient do
       end
 
       it 'lazily loads domains' do
-        allow(subject.http_client).to receive(:get).
+        expect(subject.http_client).to receive(:get).
+            exactly(5).times.
             with('domains', an_instance_of(Hash)).and_return(response)
         subject.domains.take(1000)
       end
@@ -332,20 +334,20 @@ describe Postmark::AccountApiClient do
       }
 
       it 'performs a GET request to /domains endpoint' do
-        allow(subject.http_client).to receive(:get).
+        expect(subject.http_client).to receive(:get).
             with('domains', :offset => 0, :count => 30).
             and_return(response)
         subject.get_domains
       end
 
       it 'formats the keys of returned list of domains' do
-        allow(subject.http_client).to receive(:get).and_return(response)
+        expect(subject.http_client).to receive(:get).and_return(response)
         keys = subject.get_domains.map { |s| s.keys }.flatten
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
       it 'accepts offset and count options' do
-        allow(subject.http_client).to receive(:get).
+        expect(subject.http_client).to receive(:get).
             with('domains', :offset => 10, :count => 42).
             and_return(response)
         subject.get_domains(:offset => 10, :count => 42)
@@ -357,7 +359,7 @@ describe Postmark::AccountApiClient do
       let(:response) { {'TotalCount' => 42} }
 
       it 'returns a total number of domains' do
-        allow(subject.http_client).to receive(:get).
+        expect(subject.http_client).to receive(:get).
             with('domains', an_instance_of(Hash)).and_return(response)
         expect(subject.get_domains_count).to eq(42)
       end
@@ -372,13 +374,13 @@ describe Postmark::AccountApiClient do
       }
 
       it 'performs a GET request to /domains/:id endpoint' do
-        allow(subject.http_client).to receive(:get).with("domains/42").
+        expect(subject.http_client).to receive(:get).with("domains/42").
                                                     and_return(response)
         subject.get_domain(42)
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:get).and_return(response)
+        expect(subject.http_client).to receive(:get).and_return(response)
         keys = subject.get_domain(42).keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
@@ -393,19 +395,19 @@ describe Postmark::AccountApiClient do
       }
 
       it 'performs a POST request to /domains endpoint' do
-        allow(subject.http_client).to receive(:post).
+        expect(subject.http_client).to receive(:post).
             with("domains", an_instance_of(String)).and_return(response)
         subject.create_domain(:name => 'example.com')
       end
 
       it 'converts the domain attributes names to camel case' do
-        allow(subject.http_client).to receive(:post).
+        expect(subject.http_client).to receive(:post).
             with("domains", {'FooBar' => 'bar'}.to_json).and_return(response)
         subject.create_domain(:foo_bar => 'bar')
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:post).and_return(response)
+        expect(subject.http_client).to receive(:post).and_return(response)
         keys = subject.create_domain(:foo => 'bar').keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
@@ -421,19 +423,19 @@ describe Postmark::AccountApiClient do
       }
 
       it 'performs a PUT request to /domains/:id endpoint' do
-        allow(subject.http_client).to receive(:put).
+        expect(subject.http_client).to receive(:put).
             with('domains/42', an_instance_of(String)).and_return(response)
         subject.update_domain(42, :return_path_domain => 'updated-return.example.com')
       end
 
       it 'converts the domain attributes names to camel case' do
-        allow(subject.http_client).to receive(:put).
+        expect(subject.http_client).to receive(:put).
             with('domains/42', {'FooBar' => 'bar'}.to_json).and_return(response)
         subject.update_domain(42, :foo_bar => 'bar')
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:put).and_return(response)
+        expect(subject.http_client).to receive(:put).and_return(response)
         keys = subject.update_domain(42, :foo => 'bar').keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
@@ -444,18 +446,18 @@ describe Postmark::AccountApiClient do
       let(:false_response) { {"SPFVerified" => false} }
 
       it 'performs a POST request to /domains/:id/verifyspf endpoint' do
-        allow(subject.http_client).to receive(:post).
+        expect(subject.http_client).to receive(:post).
             with('domains/42/verifyspf').and_return(response)
         subject.verified_domain_spf?(42)
       end
 
       it 'returns false when SPFVerified field of the response is false' do
-        allow(subject.http_client).to receive(:post).and_return(false_response)
+        expect(subject.http_client).to receive(:post).and_return(false_response)
         expect(subject.verified_domain_spf?(42)).to be false
       end
 
       it 'returns true when SPFVerified field of the response is true' do
-        allow(subject.http_client).to receive(:post).and_return(response)
+        expect(subject.http_client).to receive(:post).and_return(response)
         expect(subject.verified_domain_spf?(42)).to be true
       end
     end
@@ -469,13 +471,13 @@ describe Postmark::AccountApiClient do
       }
 
       it 'performs a POST request to /domains/:id/rotatedkim endpoint' do
-        allow(subject.http_client).to receive(:post).
+        expect(subject.http_client).to receive(:post).
             with('domains/42/rotatedkim').and_return(response)
         subject.rotate_domain_dkim(42)
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:post).and_return(response)
+        expect(subject.http_client).to receive(:post).and_return(response)
         keys = subject.rotate_domain_dkim(42).keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
@@ -490,13 +492,13 @@ describe Postmark::AccountApiClient do
       }
 
       it 'performs a DELETE request to /domains/:id endpoint' do
-        allow(subject.http_client).to receive(:delete).
+        expect(subject.http_client).to receive(:delete).
             with('domains/42').and_return(response)
         subject.delete_domain(42)
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:delete).and_return(response)
+        expect(subject.http_client).to receive(:delete).and_return(response)
         keys = subject.delete_sender(42).keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
@@ -510,7 +512,8 @@ describe Postmark::AccountApiClient do
       end
 
       it 'lazily loads servers' do
-        allow(subject.http_client).to receive(:get).
+        expect(subject.http_client).to receive(:get).
+            exactly(5).times.
             with('servers', an_instance_of(Hash)).and_return(response)
         subject.servers.take(100)
       end
@@ -542,19 +545,19 @@ describe Postmark::AccountApiClient do
       }
 
       it 'performs a GET request to /servers endpoint' do
-        allow(subject.http_client).to receive(:get).
+        expect(subject.http_client).to receive(:get).
             with('servers', an_instance_of(Hash)).and_return(response)
         subject.get_servers
       end
 
       it 'formats the keys of returned list of servers' do
-        allow(subject.http_client).to receive(:get).and_return(response)
+        expect(subject.http_client).to receive(:get).and_return(response)
         keys = subject.get_servers.map { |s| s.keys }.flatten
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
       it 'accepts offset and count options' do
-        allow(subject.http_client).to receive(:get).
+        expect(subject.http_client).to receive(:get).
             with('servers', :offset => 30, :count => 50).
             and_return(response)
         subject.get_servers(:offset => 30, :count => 50)
@@ -582,13 +585,13 @@ describe Postmark::AccountApiClient do
       }
 
       it 'performs a GET request to /servers/:id endpoint' do
-        allow(subject.http_client).to receive(:get).
+        expect(subject.http_client).to receive(:get).
             with('servers/42').and_return(response)
         subject.get_server(42)
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:get).and_return(response)
+        expect(subject.http_client).to receive(:get).and_return(response)
         keys = subject.get_server(42).keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
@@ -598,7 +601,7 @@ describe Postmark::AccountApiClient do
       let(:response) { {'TotalCount' => 42} }
 
       it 'returns a total number of servers' do
-        allow(subject.http_client).to receive(:get).
+        expect(subject.http_client).to receive(:get).
             with('servers', an_instance_of(Hash)).and_return(response)
         expect(subject.get_servers_count).to eq(42)
       end
@@ -619,20 +622,20 @@ describe Postmark::AccountApiClient do
       }
 
       it 'performs a POST request to /servers endpoint' do
-        allow(subject.http_client).to receive(:post).
+        expect(subject.http_client).to receive(:post).
             with('servers', an_instance_of(String)).and_return(response)
         subject.create_server(:foo => 'bar')
       end
 
       it 'converts the server attribute names to camel case' do
-        allow(subject.http_client).to receive(:post).
+        expect(subject.http_client).to receive(:post).
             with('servers', {'FooBar' => 'foo_bar'}.to_json).
             and_return(response)
         subject.create_server(:foo_bar => 'foo_bar')
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:post).and_return(response)
+        expect(subject.http_client).to receive(:post).and_return(response)
         keys = subject.create_server(:foo => 'bar').keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
@@ -659,21 +662,21 @@ describe Postmark::AccountApiClient do
       }
 
       it 'converts the server attribute names to camel case' do
-        allow(subject.http_client).to receive(:put).
+        expect(subject.http_client).to receive(:put).
             with(an_instance_of(String), {'FooBar' => 'foo_bar'}.to_json).
             and_return(response)
         subject.update_server(42, :foo_bar => 'foo_bar')
       end
 
       it 'performs a PUT request to /servers/:id endpoint' do
-        allow(subject.http_client).to receive(:put).
+        expect(subject.http_client).to receive(:put).
             with('servers/42', an_instance_of(String)).
             and_return(response)
         subject.update_server(42, :foo => 'bar')
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:put).and_return(response)
+        expect(subject.http_client).to receive(:put).and_return(response)
         keys = subject.update_server(42, :foo => 'bar').keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
@@ -688,13 +691,13 @@ describe Postmark::AccountApiClient do
       }
 
       it 'performs a DELETE request to /servers/:id endpoint' do
-        allow(subject.http_client).to receive(:delete).
+        expect(subject.http_client).to receive(:delete).
             with('servers/42').and_return(response)
         subject.delete_server(42)
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:delete).and_return(response)
+        expect(subject.http_client).to receive(:delete).and_return(response)
         keys = subject.delete_server(42).keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
@@ -711,7 +714,7 @@ describe Postmark::AccountApiClient do
       let(:request_data) {{:source_server_id => 1, :destination_server_id => 2, :perform_changes => false}}
 
       it 'gets templates info and converts it to ruby format' do
-        allow(subject.http_client).to receive(:put).and_return(response)
+        expect(subject.http_client).to receive(:put).and_return(response)
         templates = subject.push_templates({:source_server_id => 1, :destination_server_id => 2, :perform_changes => false} )
 
         expect(templates.size).to eq(2)
@@ -720,7 +723,7 @@ describe Postmark::AccountApiClient do
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:put).and_return(response)
+        expect(subject.http_client).to receive(:put).and_return(response)
         templates = subject.push_templates({:source_server_id => 1, :destination_server_id => 2, :perform_changes => false} )
 
         keys = templates.map { |template| template.keys }.flatten
@@ -737,13 +740,13 @@ describe Postmark::AccountApiClient do
       }
 
       it 'performs a GET request to /data-removals/:id endpoint' do
-        allow(subject.http_client).to receive(:get).
+        expect(subject.http_client).to receive(:get).
           with('data-removals/42').and_return(response)
         subject.get_data_removal_status(42)
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:get).and_return(response)
+        expect(subject.http_client).to receive(:get).and_return(response)
         keys = subject.get_data_removal_status(42).keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
@@ -758,13 +761,13 @@ describe Postmark::AccountApiClient do
       }
 
       it 'performs a POST request to /data-removals endpoint' do
-        allow(subject.http_client).to receive(:post).
+        expect(subject.http_client).to receive(:post).
           with('data-removals', an_instance_of(String)).and_return(response)
         subject.request_data_removal(:foo => 'bar')
       end
 
       it 'formats the keys of returned response' do
-        allow(subject.http_client).to receive(:post).and_return(response)
+        expect(subject.http_client).to receive(:post).and_return(response)
         keys = subject.request_data_removal(:foo => 'bar').keys
         expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end

--- a/spec/unit/postmark/api_client_spec.rb
+++ b/spec/unit/postmark/api_client_spec.rb
@@ -161,7 +161,7 @@ describe Postmark::ApiClient do
     end
 
     it "proxies errors" do
-      allow(http_client).to receive(:post).and_raise(Postmark::TimeoutError)
+      expect(http_client).to receive(:post).and_raise(Postmark::TimeoutError)
       expect {subject}.to raise_error(Postmark::TimeoutError)
     end
 
@@ -188,7 +188,7 @@ describe Postmark::ApiClient do
     end
 
     it "proxies errors" do
-      allow(http_client).to receive(:post).and_raise(Postmark::TimeoutError)
+      expect(http_client).to receive(:post).and_raise(Postmark::TimeoutError)
       expect {subject}.to raise_error(Postmark::TimeoutError)
     end
 
@@ -262,7 +262,7 @@ describe Postmark::ApiClient do
       end
 
       it 'loads outbound messages' do
-        allow(api_client.http_client).to receive(:get).
+        expect(api_client.http_client).to receive(:get).
             with('messages/outbound', an_instance_of(Hash)).and_return(response)
         expect(api_client.messages.count).to eq(5)
       end
@@ -276,7 +276,7 @@ describe Postmark::ApiClient do
       end
 
       it 'loads inbound messages' do
-        allow(api_client.http_client).to receive(:get).with('messages/inbound', an_instance_of(Hash)).and_return(response)
+        expect(api_client.http_client).to receive(:get).with('messages/inbound', an_instance_of(Hash)).and_return(response)
         expect(api_client.messages(:inbound => true).count).to eq(5)
       end
     end
@@ -308,19 +308,22 @@ describe Postmark::ApiClient do
     let(:response) {{'TotalCount' => 42}}
 
     context 'given outbound' do
-
-      it 'requests and returns outbound messages count' do
-        allow(api_client.http_client).to receive(:get).
+      it 'requests and returns outbound messages count by default' do
+        expect(api_client.http_client).to receive(:get).
             with('messages/outbound', an_instance_of(Hash)).and_return(response)
         expect(api_client.get_messages_count).to eq(42)
-        expect(api_client.get_messages_count(:inbound => false)).to eq(42)
       end
 
+      it 'requests and returns outbound messages count when inbound => false' do
+        expect(api_client.http_client).to receive(:get).
+          with('messages/outbound', an_instance_of(Hash)).and_return(response)
+        expect(api_client.get_messages_count(:inbound => false)).to eq(42)
+      end
     end
 
     context 'given inbound' do
       it 'requests and returns inbound messages count' do
-        allow(api_client.http_client).to receive(:get).
+        expect(api_client.http_client).to receive(:get).
             with('messages/inbound', an_instance_of(Hash)).and_return(response)
         expect(api_client.get_messages_count(:inbound => true)).to eq(42)
       end
@@ -382,7 +385,7 @@ describe Postmark::ApiClient do
     end
 
     it 'requests data at /bounces' do
-      allow(api_client.http_client).to receive(:get).
+      expect(api_client.http_client).to receive(:get).
           with('bounces', an_instance_of(Hash)).
           and_return('TotalCount' => 1, 'Bounces' => [{}])
       expect(api_client.bounces.first(5).count).to eq(1)
@@ -394,9 +397,10 @@ describe Postmark::ApiClient do
     let(:response) {{"Bounces" => []}}
 
     it 'requests data at /bounces' do
-      allow(http_client).to receive(:get).with("bounces", options) {response}
-      expect(api_client.get_bounces(options)).to be_an(Array)
-      expect(api_client.get_bounces(options).count).to be_zero
+      expect(http_client).to receive(:get).with("bounces", options) {response}
+      result = api_client.get_bounces(options)
+      expect(result).to be_an(Array)
+      expect(result.count).to be_zero
     end
   end
 
@@ -434,7 +438,7 @@ describe Postmark::ApiClient do
     end
 
     it 'performs a GET request to /opens/tags' do
-      allow(api_client.http_client).to receive(:get).
+      expect(api_client.http_client).to receive(:get).
           with('messages/outbound/opens', an_instance_of(Hash)).
           and_return('TotalCount' => 1, 'Opens' => [{}])
       expect(api_client.opens.first(5).count).to eq(1)
@@ -447,7 +451,7 @@ describe Postmark::ApiClient do
     end
 
     it 'performs a GET request to /clicks/tags' do
-      allow(api_client.http_client).to receive(:get).
+      expect(api_client.http_client).to receive(:get).
           with('messages/outbound/clicks', an_instance_of(Hash)).
           and_return('TotalCount' => 1, 'Clicks' => [{}])
       expect(api_client.clicks.first(5).count).to eq(1)
@@ -459,9 +463,10 @@ describe Postmark::ApiClient do
     let(:response) {{'Opens' => [], 'TotalCount' => 0}}
 
     it 'performs a GET request to /messages/outbound/opens' do
-      allow(http_client).to receive(:get).with('messages/outbound/opens', options) {response}
-      expect(api_client.get_opens(options)).to be_an(Array)
-      expect(api_client.get_opens(options).count).to be_zero
+      expect(http_client).to receive(:get).with('messages/outbound/opens', options) {response}
+      result = api_client.get_opens(options)
+      expect(result).to be_an(Array)
+      expect(result.count).to be_zero
     end
   end
 
@@ -470,9 +475,10 @@ describe Postmark::ApiClient do
     let(:response) {{'Clicks' => [], 'TotalCount' => 0}}
 
     it 'performs a GET request to /messages/outbound/clicks' do
-      allow(http_client).to receive(:get).with('messages/outbound/clicks', options) {response}
-      expect(api_client.get_clicks(options)).to be_an(Array)
-      expect(api_client.get_clicks(options).count).to be_zero
+      expect(http_client).to receive(:get).with('messages/outbound/clicks', options) {response}
+      result = api_client.get_clicks(options)
+      expect(result).to be_an(Array)
+      expect(result.count).to be_zero
     end
   end
 
@@ -482,9 +488,10 @@ describe Postmark::ApiClient do
     let(:response) {{'Opens' => [], 'TotalCount' => 0}}
 
     it 'performs a GET request to /messages/outbound/opens' do
-      allow(http_client).to receive(:get).with("messages/outbound/opens/#{message_id}", options).and_return(response)
-      expect(api_client.get_opens_by_message_id(message_id, options)).to be_an(Array)
-      expect(api_client.get_opens_by_message_id(message_id, options).count).to be_zero
+      expect(http_client).to receive(:get).with("messages/outbound/opens/#{message_id}", options).and_return(response)
+      result = api_client.get_opens_by_message_id(message_id, options)
+      expect(result).to be_an(Array)
+      expect(result.count).to be_zero
     end
   end
 
@@ -494,9 +501,10 @@ describe Postmark::ApiClient do
     let(:response) {{'Clicks' => [], 'TotalCount' => 0}}
 
     it 'performs a GET request to /messages/outbound/clicks' do
-      allow(http_client).to receive(:get).with("messages/outbound/clicks/#{message_id}", options).and_return(response)
-      expect(api_client.get_clicks_by_message_id(message_id, options)).to be_an(Array)
-      expect(api_client.get_clicks_by_message_id(message_id, options).count).to be_zero
+      expect(http_client).to receive(:get).with("messages/outbound/clicks/#{message_id}", options).and_return(response)
+      result = api_client.get_clicks_by_message_id(message_id, options)
+      expect(result).to be_an(Array)
+      expect(result.count).to be_zero
     end
   end
 
@@ -508,7 +516,7 @@ describe Postmark::ApiClient do
     end
 
     it 'performs a GET request to /opens/tags' do
-      allow(api_client.http_client).to receive(:get).
+      expect(api_client.http_client).to receive(:get).
           with("messages/outbound/opens/#{message_id}", an_instance_of(Hash)).
           and_return('TotalCount' => 1, 'Opens' => [{}])
       expect(api_client.opens_by_message_id(message_id).first(5).count).to eq(1)
@@ -523,7 +531,7 @@ describe Postmark::ApiClient do
     end
 
     it 'performs a GET request to /clicks/tags' do
-      allow(api_client.http_client).to receive(:get).
+      expect(api_client.http_client).to receive(:get).
           with("messages/outbound/clicks/#{message_id}", an_instance_of(Hash)).
           and_return('TotalCount' => 1, 'Clicks' => [{}])
       expect(api_client.clicks_by_message_id(message_id).first(5).count).to eq(1)
@@ -536,13 +544,13 @@ describe Postmark::ApiClient do
       let(:response) {{'Rule' => 'example.com'}}
 
       it 'performs a POST request to /triggers/inboundrules with given options' do
-        allow(http_client).to receive(:post).with('triggers/inboundrules',
+        expect(http_client).to receive(:post).with('triggers/inboundrules',
                                                   {'Rule' => 'example.com'}.to_json)
         api_client.create_trigger(:inbound_rules, options)
       end
 
       it 'symbolizes response keys' do
-        allow(http_client).to receive(:post).and_return(response)
+        expect(http_client).to receive(:post).and_return(response)
         expect(api_client.create_trigger(:inbound_rules, options)).to eq(:rule => 'example.com')
       end
     end
@@ -552,12 +560,12 @@ describe Postmark::ApiClient do
     let(:id) {42}
 
     it 'performs a GET request to /triggers/tags/:id' do
-      allow(http_client).to receive(:get).with("triggers/tags/#{id}")
+      expect(http_client).to receive(:get).with("triggers/tags/#{id}")
       api_client.get_trigger(:tags, id)
     end
 
     it 'symbolizes response keys' do
-      allow(http_client).to receive(:get).and_return('Foo' => 'Bar')
+      expect(http_client).to receive(:get).and_return('Foo' => 'Bar')
       expect(api_client.get_trigger(:tags, id)).to eq(:foo => 'Bar')
     end
   end
@@ -567,12 +575,12 @@ describe Postmark::ApiClient do
       let(:id) {42}
 
       it 'performs a DELETE request to /triggers/tags/:id' do
-        allow(http_client).to receive(:delete).with("triggers/tags/#{id}")
+        expect(http_client).to receive(:delete).with("triggers/tags/#{id}")
         api_client.delete_trigger(:tags, id)
       end
 
       it 'symbolizes response keys' do
-        allow(http_client).to receive(:delete).and_return('Foo' => 'Bar')
+        expect(http_client).to receive(:delete).and_return('Foo' => 'Bar')
         expect(api_client.delete_trigger(:tags, id)).to eq(:foo => 'Bar')
       end
     end
@@ -581,12 +589,12 @@ describe Postmark::ApiClient do
       let(:id) {42}
 
       it 'performs a DELETE request to /triggers/inboundrules/:id' do
-        allow(http_client).to receive(:delete).with("triggers/inboundrules/#{id}")
+        expect(http_client).to receive(:delete).with("triggers/inboundrules/#{id}")
         api_client.delete_trigger(:inbound_rules, id)
       end
 
       it 'symbolizes response keys' do
-        allow(http_client).to receive(:delete).and_return('Rule' => 'example.com')
+        expect(http_client).to receive(:delete).and_return('Rule' => 'example.com')
         expect(api_client.delete_trigger(:tags, id)).to eq(:rule => 'example.com')
       end
     end
@@ -599,9 +607,10 @@ describe Postmark::ApiClient do
       let(:response) {{'InboundRules' => [], 'TotalCount' => 0}}
 
       it 'performs a GET request to /triggers/inboundrules' do
-        allow(http_client).to receive(:get).with('triggers/inboundrules', options) {response}
-        expect(api_client.get_triggers(:inbound_rules, options)).to be_an(Array)
-        expect(api_client.get_triggers(:inbound_rules, options).count).to be_zero
+        expect(http_client).to receive(:get).with('triggers/inboundrules', options) {response}
+        result = api_client.get_triggers(:inbound_rules, options)
+        expect(result).to be_an(Array)
+        expect(result.count).to be_zero
       end
     end
   end
@@ -612,7 +621,7 @@ describe Postmark::ApiClient do
     end
 
     it 'performs a GET request to /triggers/tags' do
-      allow(api_client.http_client).to receive(:get).
+      expect(api_client.http_client).to receive(:get).
           with('triggers/tags', an_instance_of(Hash)).
           and_return('TotalCount' => 1, 'Tags' => [{}])
       expect(api_client.triggers(:tags).first(5).count).to eq(1)
@@ -688,7 +697,7 @@ describe Postmark::ApiClient do
     end
 
     it 'requests data at /templates' do
-      allow(api_client.http_client).to receive(:get).
+      expect(api_client.http_client).to receive(:get).
           with('templates', an_instance_of(Hash)).
           and_return('TotalCount' => 1, 'Templates' => [{}])
       expect(api_client.templates.first(5).count).to eq(1)
@@ -1025,7 +1034,7 @@ describe Postmark::ApiClient do
     subject(:result) { api_client.get_message_streams(:offset => 22, :count => 33) }
 
     before do
-      allow(http_client).to receive(:get).
+      expect(http_client).to receive(:get).
         with('message-streams', :offset => 22, :count => 33).
         and_return({ 'TotalCount' => 1, 'MessageStreams' => [{'Name' => 'abc'}]})
     end
@@ -1045,7 +1054,7 @@ describe Postmark::ApiClient do
     it { is_expected.to be_kind_of(Enumerable) }
 
     it 'requests data at /message-streams' do
-      allow(http_client).to receive(:get).
+      expect(http_client).to receive(:get).
         with('message-streams', anything).
         and_return('TotalCount' => 1, 'MessageStreams' => [{}])
       expect(subject.first(5).count).to eq(1)
@@ -1056,7 +1065,7 @@ describe Postmark::ApiClient do
     subject(:result) { api_client.get_message_stream(123) }
 
     before do
-      allow(http_client).to receive(:get).
+      expect(http_client).to receive(:get).
         with('message-streams/123').
         and_return({
           'Id' => 'xxx',


### PR DESCRIPTION
## What

Replaces `allow` with `expect` throughout, where we actually want to verify that a certain method is called.

## Why

As discussed in https://github.com/ActiveCampaign/postmark-gem/pull/147#discussion_r1354414011, the tests were relying on no exceptions being raised, rather than verifying correct behavior.