### PR TITLE
fixing visibility of CHANGELOG on rubygems.org

### DIFF
--- a/postmark.gemspec
+++ b/postmark.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |s|
   s.executables      = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths    = ["lib"]
 
+  s.metadata["changelog_uri"] = "https://github.com/ActiveCampaign/postmark-gem/blob/main/CHANGELOG.rdoc"
+
   s.post_install_message = %q{
     ==================
     Thanks for installing the postmark gem. If you don't have an account, please


### PR DESCRIPTION
This PR makes the `CHANGELOG.rdoc` file discoverable on Rubygems.org

The screenshot shows that the reference to the CHANGELOG is currently missing:

![Screenshot 2024-02-07 at 07 30 43](https://github.com/ActiveCampaign/postmark-gem/assets/22553/5059038f-24af-4aac-a9dc-cc9074ebeb1e)

After merging and the next release, it will show up like this:

![Screenshot 2024-02-07 at 07 33 21](https://github.com/ActiveCampaign/postmark-gem/assets/22553/3e87f5d2-c78c-47f5-9949-2fbec384f092)
