### PR TITLE
Fix: Postmark::AccountApiClient mutates "options" argument

### DIFF
--- a/lib/postmark/account_api_client.rb
+++ b/lib/postmark/account_api_client.rb
@@ -3,6 +3,7 @@ module Postmark
   class AccountApiClient < Client
 
     def initialize(api_token, options = {})
+      options = options.dup
       options[:auth_header_name] = 'X-Postmark-Account-Token'
       super
     end

--- a/spec/unit/postmark/account_api_client_spec.rb
+++ b/spec/unit/postmark/account_api_client_spec.rb
@@ -12,6 +12,13 @@ describe Postmark::AccountApiClient do
     expect { subject.new(api_token, :http_read_timeout => 5) }.not_to raise_error
   end
 
+  it "doesn't mutate options hash" do
+    options = { my_option: true }
+    subject.new(api_token, options)
+
+    expect(options).to eq({ my_option: true})
+  end
+
   context 'instance' do
     subject { Postmark::AccountApiClient.new(api_token) }
 

--- a/spec/unit/postmark/account_api_client_spec.rb
+++ b/spec/unit/postmark/account_api_client_spec.rb
@@ -13,10 +13,10 @@ describe Postmark::AccountApiClient do
   end
 
   it "doesn't mutate options hash" do
-    options = { my_option: true }
+    options = { "my_option" => true }
     subject.new(api_token, options)
 
-    expect(options).to eq({ my_option: true})
+    expect(options).to eq({ "my_option" => true })
   end
 
   context 'instance' do


### PR DESCRIPTION
Closes https://github.com/ActiveCampaign/postmark-gem/issues/153
