### PR TITLE
Fix failing legacy tests

### DIFF
--- a/postmark.gemspec
+++ b/postmark.gemspec
@@ -21,7 +21,9 @@ Gem::Specification.new do |s|
   s.executables      = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths    = ["lib"]
 
-  s.metadata["changelog_uri"] = "https://github.com/ActiveCampaign/postmark-gem/blob/main/CHANGELOG.rdoc"
+  if s.respond_to?(:metadata) # not supported in Bundler/Ruby 1.x
+    s.metadata["changelog_uri"] = "https://github.com/ActiveCampaign/postmark-gem/blob/main/CHANGELOG.rdoc"
+  end
 
   s.post_install_message = %q{
     ==================


### PR DESCRIPTION
## What

Addresses [error](https://app.circleci.com/pipelines/github/ActiveCampaign/postmark-gem/197/workflows/a222aad0-e4e7-41a1-a9ea-f17d7100d2fd/jobs/2173) seen in old ruby versions since #151 :

```
[!] There was an error parsing `Gemfile.legacy`: 
[!] There was an error while loading `postmark.gemspec`: undefined method `metadata' for #<Gem::Specification:0x2e5d6c8>. Bundler cannot continue.
```